### PR TITLE
Linked inpaths and outpaths for processing steps

### DIFF
--- a/src/python/mosaic-pipeline.py
+++ b/src/python/mosaic-pipeline.py
@@ -579,7 +579,7 @@ def process(dirs, configs, dryrun=False, verbose=False):
                 if not deskew and mip:
                     step = settings['waveform']['xz-stage-offset']['interval'][ch]
                     if crop:
-                        inpath = output_crop / tag_filename(f, '_crop')
+                        inpath = output_crop / tag_filename(out_f, '_crop')
                         outpath = output_crop_mip / tag_filename(out_f, '_crop_mip')
                         tmp = cmd_mip + ' -q %s -o %s %s;' % (step, outpath, inpath)
                         cmd.append(tmp)
@@ -591,7 +591,7 @@ def process(dirs, configs, dryrun=False, verbose=False):
 
                 if deskew:
                     if crop:
-                        inpath = output_crop / tag_filename(f, '_crop')
+                        inpath = output_crop / tag_filename(out_f, '_crop')
                     else:
                         inpath = d / f
                     outpath = output_deskew / tag_filename(out_f, '_deskew')
@@ -603,16 +603,16 @@ def process(dirs, configs, dryrun=False, verbose=False):
 
                     # create mips for deskew
                     if mip:
-                        inpath = output_deskew / tag_filename(f, '_deskew')
+                        inpath = output_deskew / tag_filename(out_f, '_deskew')
                         outpath = output_deskew_mip / tag_filename(out_f, '_deskew_mip')
                         tmp = cmd_mip + ' -q %s -o %s %s;' % (step, outpath, inpath)
                         cmd.append(tmp)
 
                 if decon:
                     if deskew:
-                        inpath = output_deskew / tag_filename(f, '_deskew')
+                        inpath = output_deskew / tag_filename(out_f, '_deskew')
                     elif crop:
-                        inpath = output_crop / tag_filename(f, '_crop')
+                        inpath = output_crop / tag_filename(out_f, '_crop')
                     else:
                         inpath = d / f
 
@@ -630,7 +630,7 @@ def process(dirs, configs, dryrun=False, verbose=False):
 
                     # create mips for decon
                     if mip:
-                        inpath = output_decon / tag_filename(f, '_decon')
+                        inpath = output_decon / tag_filename(out_f, '_decon')
                         outpath = output_decon_mip / tag_filename(out_f, '_decon_mip')
                         tmp = cmd_mip + ' -q %s -o %s %s;' % (step, outpath , inpath)
                         cmd.append(tmp)

--- a/src/python/mosaic-pipeline.py
+++ b/src/python/mosaic-pipeline.py
@@ -669,12 +669,8 @@ if __name__ == '__main__':
 
     # load config file
     configs = load_configs(args.input)
-    original_stdout = sys.stdout
-    with open('output.txt','w') as file:
-        sys.stdout = file
+    if args.dryrun:
         print(configs)
-        sys.stdout.flush()
-    sys.stdout = original_stdout
 
     # get dictionary of processed files
     root_dir = Path(configs['paths']['root'])

--- a/src/python/mosaic-pipeline.py
+++ b/src/python/mosaic-pipeline.py
@@ -13,6 +13,7 @@ import time
 import datetime
 from pathlib import Path, PurePath
 from sys import exit
+import sys
 import mosaicsettings2json
 
 def parse_args():
@@ -669,6 +670,7 @@ if __name__ == '__main__':
     # load config file
     configs = load_configs(args.input)
     print(configs)
+    sys.stdout.flush()
 
     # get dictionary of processed files
     root_dir = Path(configs['paths']['root'])

--- a/src/python/mosaic-pipeline.py
+++ b/src/python/mosaic-pipeline.py
@@ -669,8 +669,12 @@ if __name__ == '__main__':
 
     # load config file
     configs = load_configs(args.input)
-    print(configs)
-    sys.stdout.flush()
+    original_stdout = sys.stdout
+    with open('output.txt','w') as file:
+        sys.stdout = file
+        print(configs)
+        sys.stdout.flush()
+    sys.stdout = original_stdout
 
     # get dictionary of processed files
     root_dir = Path(configs['paths']['root'])

--- a/src/python/mosaic-pipeline.py
+++ b/src/python/mosaic-pipeline.py
@@ -233,6 +233,8 @@ def load_configs(path):
                 print('warning: bdv option \'%s\' in config.json is not supported' % key)
                 del configs['bdv'][key]
 
+    print(configs)
+
     return configs
 
 def get_processed_json(path):

--- a/src/python/mosaic-pipeline.py
+++ b/src/python/mosaic-pipeline.py
@@ -392,6 +392,7 @@ def process(dirs, configs, dryrun=False, verbose=False):
         # bdv_file setup
         bdv_file = False
         if params_bdv:
+            print('saving in bdv naming format...')
             bdv_file = True
 
         # crop setup

--- a/src/python/mosaic-pipeline.py
+++ b/src/python/mosaic-pipeline.py
@@ -233,8 +233,6 @@ def load_configs(path):
                 print('warning: bdv option \'%s\' in config.json is not supported' % key)
                 del configs['bdv'][key]
 
-    print(configs)
-
     return configs
 
 def get_processed_json(path):
@@ -670,6 +668,7 @@ if __name__ == '__main__':
 
     # load config file
     configs = load_configs(args.input)
+    print(configs)
 
     # get dictionary of processed files
     root_dir = Path(configs['paths']['root'])


### PR DESCRIPTION
Changed the inpath names for processing that takes compound steps (e.g. crop + decon +mip) so that the out files are linked together and the steps are propagated through,